### PR TITLE
Bugfix: correct month and date params

### DIFF
--- a/client/js/main.js
+++ b/client/js/main.js
@@ -129,8 +129,8 @@ function ajaxCall() {
         lat: lat,
         lon: lon,
         year: day.year(),
-        month: day.month(),
-        day: day.day(),
+        month: day.month() + 1,  //Zero Indexed
+        day: day.date(),
         hour: day.hour(),
         minute: day.minute(),
         boundLatMin: bounds.getSouth(),


### PR DESCRIPTION
Small fix. AJAX Post request now sends correct month and date. Previously months were off by one due to zero index and it was sending day of the week instead of date.
