### PR TITLE
Fix default location on geolocation failure.

### DIFF
--- a/client/js/main.js
+++ b/client/js/main.js
@@ -65,7 +65,11 @@ function handleNoGeolocation(errorFlag) {
     }
 
     //default location: Code Fellows
-    buildMap([47.6235, -122.3360]);
+    pos = {
+        lat: 47.6235,
+        lon: -122.3360
+    };
+    buildMap();
 }
 
 function buildMap() {


### PR DESCRIPTION
Current implementation of getting geolocation fails due to deprecation on insecure origins. See:
- https://sites.google.com/a/chromium.org/dev/Home/chromium-security/deprecating-powerful-features-on-insecure-origins.

Fixed included for fallback location.
